### PR TITLE
feat(deploy): copy-paste docker compose using GHCR images

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,9 +2,9 @@ NODE_ENV=production
 BEPORT=8080
 JWT_SECRET=your-super-secret-jwt-key-change-this
 BEURL=https://beer.sv-ada.nl
-# API_UPSTREAM is derived from BEPORT in docker-compose.deploy.yml
-# (http://backend:${BEPORT}). Only set it to proxy the frontend to an
-# external/custom backend target:
+# API_UPSTREAM is derived from BEPORT in docker-compose.yml and
+# docker-compose.deploy.yml (http://backend:${BEPORT}). Only set it to proxy
+# the frontend to an external/custom backend target:
 # API_UPSTREAM=http://backend:8080
 
 FEURL=https://beer.sv-ada.nl

--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,10 @@ NODE_ENV=production
 BEPORT=8080
 JWT_SECRET=your-super-secret-jwt-key-change-this
 BEURL=https://beer.sv-ada.nl
-API_UPSTREAM=http://backend:8080
+# API_UPSTREAM is derived from BEPORT in docker-compose.deploy.yml
+# (http://backend:${BEPORT}). Only set it to proxy the frontend to an
+# external/custom backend target:
+# API_UPSTREAM=http://backend:8080
 
 FEURL=https://beer.sv-ada.nl
 FEPORT=443

--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,11 @@ BEURL=https://beer.sv-ada.nl
 # DOCKER_IMAGE_NAMESPACE=athype
 # IMAGE_TAG=latest
 
+# Host port for the web UI when using docker-compose.deploy-host-proxy.yml
+# (hosts with their own reverse proxy). Container-based proxies (Coolify,
+# Traefik) can reach frontend:80 directly and do not need this.
+# WEBPORT=8080
+
 FEURL=https://beer.sv-ada.nl
 FEPORT=443
 

--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,14 @@ BEURL=https://beer.sv-ada.nl
 # the frontend to an external/custom backend target:
 # API_UPSTREAM=http://backend:8080
 
+# Image location for docker-compose.deploy.yml. Mirrors the build workflow's
+# DOCKER_REGISTRY / DOCKER_IMAGE_NAMESPACE repo variables (see "Docker Image
+# CI/CD" in README). Defaults: ghcr.io and athype. Pin a rollout with IMAGE_TAG
+# (e.g. sha-XXXXXXX) instead of editing the compose file.
+# DOCKER_REGISTRY=ghcr.io
+# DOCKER_IMAGE_NAMESPACE=athype
+# IMAGE_TAG=latest
+
 FEURL=https://beer.sv-ada.nl
 FEPORT=443
 

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ docker compose -f docker-compose.deploy.yml up -d
 ```
 
 Notes:
-- Images: `ghcr.io/athype/beerswipe-backend` and `ghcr.io/athype/beerswipe-frontend` (tag `latest`; pin a `sha-*` tag for reproducible rollouts).
+- Images: `${DOCKER_REGISTRY:-ghcr.io}/${DOCKER_IMAGE_NAMESPACE:-athype}/beerswipe-{backend,frontend}`. The variables mirror the build workflow's `DOCKER_REGISTRY` / `DOCKER_IMAGE_NAMESPACE` (see "Docker Image CI/CD" above), so forks and custom registries work without YAML edits. Tag is set via `IMAGE_TAG` (default `latest`; e.g. `IMAGE_TAG=sha-XXXXXXX` to pin a rollout).
 - The production frontend uses a relative `/api/v1` path and nginx proxies to the backend via `API_UPSTREAM` at startup, so no URL is baked into the image.
 - `API_UPSTREAM` defaults to `http://backend:${BEPORT}`, so it stays consistent when only `BEPORT` is changed; set it explicitly only for an external/custom backend target.
 - Backend uploads go to the named `backend_uploads` volume (no host path needed).

--- a/README.md
+++ b/README.md
@@ -242,6 +242,15 @@ Notes:
 - Backend uploads go to the named `backend_uploads` volume (no host path needed).
 - The backend waits for Postgres to report healthy before starting, so first boot on a fresh remote is reliable.
 
+### Variant: host with its own reverse proxy (Coolify, Traefik, nginx)
+
+On hosts that already terminate TLS and route traffic (Coolify, a shared Traefik/nginx, ...), use `docker-compose.deploy-host-proxy.yml` instead: the same stack without the built-in Caddy service, and it does not bind ports 80/443. Point the host proxy at the frontend service:
+
+- container-based proxy on the same Docker network (Coolify/Traefik): `http://frontend:80`
+- host-level proxy (nginx on the host): `http://127.0.0.1:${WEBPORT:-8080}`
+
+The frontend nginx proxies `/api/v1` to the backend internally, so a single upstream is enough. Deploy and update commands are the same as above with `-f docker-compose.deploy-host-proxy.yml`.
+
 ## Frontend Container Runtime (Compose + Coolify)
 
 The frontend production container now uses nginx template rendering at startup, so no custom entrypoint script is needed.

--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ docker compose -f docker-compose.deploy.yml up -d
 Notes:
 - Images: `ghcr.io/athype/beerswipe-backend` and `ghcr.io/athype/beerswipe-frontend` (tag `latest`; pin a `sha-*` tag for reproducible rollouts).
 - The production frontend uses a relative `/api/v1` path and nginx proxies to the backend via `API_UPSTREAM` at startup, so no URL is baked into the image.
+- `API_UPSTREAM` defaults to `http://backend:${BEPORT}`, so it stays consistent when only `BEPORT` is changed; set it explicitly only for an external/custom backend target.
 - Backend uploads go to the named `backend_uploads` volume (no host path needed).
 - The backend waits for Postgres to report healthy before starting, so first boot on a fresh remote is reliable.
 

--- a/README.md
+++ b/README.md
@@ -212,6 +212,35 @@ Tags produced:
 - branch tag (for example `main`)
 - commit SHA tag
 
+## Remote Deployment (Copy-Paste, Prebuilt Images)
+
+`docker-compose.deploy.yml` deploys the prebuilt GHCR images without needing the source repo or a build toolchain on the target host. Only the compose file, `Caddyfile` and `.env` are needed:
+
+```bash
+# On any remote with Docker + Compose v2
+mkdir -p /opt/beerswipe && cd /opt/beerswipe
+# copy docker-compose.deploy.yml, Caddyfile and .env.example from this repo
+
+cp .env.example .env
+nano .env  # set JWT_SECRET, DB_PASSWORD, DOMAIN, RP_ID, FEURL for production
+
+docker compose -f docker-compose.deploy.yml up -d
+docker compose -f docker-compose.deploy.yml logs -f caddy
+```
+
+Update an existing deployment:
+
+```bash
+docker compose -f docker-compose.deploy.yml pull
+docker compose -f docker-compose.deploy.yml up -d
+```
+
+Notes:
+- Images: `ghcr.io/athype/beerswipe-backend` and `ghcr.io/athype/beerswipe-frontend` (tag `latest`; pin a `sha-*` tag for reproducible rollouts).
+- The production frontend uses a relative `/api/v1` path and nginx proxies to the backend via `API_UPSTREAM` at startup, so no URL is baked into the image.
+- Backend uploads go to the named `backend_uploads` volume (no host path needed).
+- The backend waits for Postgres to report healthy before starting, so first boot on a fresh remote is reliable.
+
 ## Frontend Container Runtime (Compose + Coolify)
 
 The frontend production container now uses nginx template rendering at startup, so no custom entrypoint script is needed.

--- a/docker-compose.deploy-host-proxy.yml
+++ b/docker-compose.deploy-host-proxy.yml
@@ -1,69 +1,43 @@
-# Copy-paste production deployment for beerswipe-v2 using prebuilt images.
+# Copy-paste production deployment for beerswipe-v2 on hosts that ALREADY
+# have a reverse proxy (Coolify, Traefik, nginx, host Caddy, ...).
 #
-# Unlike docker-compose.yml (which builds images from source), this file pulls
-# the images published by .github/workflows/docker-build-push.yml:
+# Same stack as docker-compose.deploy.yml, but WITHOUT the built-in Caddy
+# service: this stack does not bind ports 80/443. TLS termination and routing
+# are the host's job. Only one upstream is needed on the host proxy:
+#
+#   - container-based proxy on the same Docker network (Coolify/Traefik):
+#       http://frontend:80
+#   - host-level proxy (nginx on the host, other compose stacks):
+#       http://127.0.0.1:${WEBPORT:-8080}
+#
+# The frontend nginx proxies /api/v1 to the backend internally (API_UPSTREAM,
+# injected at container start), so the proxy never needs to know about the
+# backend or postgres services.
+#
+# Images are pulled from the registry published by
+# .github/workflows/docker-build-push.yml, using the same variables as
+# docker-compose.deploy.yml:
 #   - ${DOCKER_REGISTRY:-ghcr.io}/${DOCKER_IMAGE_NAMESPACE:-athype}/beerswipe-backend
 #   - ${DOCKER_REGISTRY:-ghcr.io}/${DOCKER_IMAGE_NAMESPACE:-athype}/beerswipe-frontend
+# Pin a rollout with IMAGE_TAG (e.g. IMAGE_TAG=sha-bb04677), no YAML edits.
 #
-# The image location uses the same variables the build workflow honors
-# (DOCKER_REGISTRY, DOCKER_IMAGE_NAMESPACE), so forks and custom registries
-# work without editing YAML:
-#   DOCKER_REGISTRY=registry.example.com DOCKER_IMAGE_NAMESPACE=myorg
-#
-# No source checkout, Node toolchain or build step is needed on the target host.
-#
-# Deploy on any remote with Docker + Compose v2 (>= 2.23):
-#   1. Put this file, the Caddyfile and a .env next to each other, e.g.:
+# Deploy on any host with Docker + Compose v2 (>= 2.23):
+#   1. Put this file and a .env next to each other, e.g.:
 #        mkdir -p /opt/beerswipe && cd /opt/beerswipe
-#        # copy docker-compose.deploy.yml + Caddyfile + .env.example from this repo
+#        # copy docker-compose.deploy-host-proxy.yml + .env.example from this repo
 #   2. cp .env.example .env && nano .env
 #      -> MUST set JWT_SECRET, DB_PASSWORD, DOMAIN, RP_ID and FEURL for production.
 #      -> The defaults in this file let the stack boot, but are NOT secure.
-#   3. docker compose -f docker-compose.deploy.yml up -d
-#   4. docker compose -f docker-compose.deploy.yml logs -f caddy
+#   3. docker compose -f docker-compose.deploy-host-proxy.yml up -d
 #
 # Update an existing deployment (pulls new images and recreates changed services):
-#   docker compose -f docker-compose.deploy.yml pull
-#   docker compose -f docker-compose.deploy.yml up -d
+#   docker compose -f docker-compose.deploy-host-proxy.yml pull
+#   docker compose -f docker-compose.deploy-host-proxy.yml up -d
 #
-# Reproducible rollouts: pin images to a commit tag instead of latest via the
-# IMAGE_TAG variable, e.g. IMAGE_TAG=sha-bb04677 in .env (no YAML edits).
-#
-# Host already has its own reverse proxy (Coolify, Traefik, nginx)? Use
-# docker-compose.deploy-host-proxy.yml instead: same stack without Caddy.
-#
-# Requirements on the remote:
-#   - Docker Engine + Docker Compose v2
-#   - Ports 80 and 443 reachable (Caddy does automatic HTTPS via Let's Encrypt)
-#   - DNS A record for your domain pointing at the server (unless DOMAIN=localhost)
-#
-# Note: the production frontend build uses a relative /api/v1 path and nginx
-# proxies to the backend via API_UPSTREAM at container start, so no URL is
-# baked into the GHCR image. One image works on any remote.
+# Note: the production frontend build uses a relative /api/v1 path, so no URL
+# is baked into the GHCR image. One image works on any host.
 
 services:
-  # Caddy Reverse Proxy (automatic HTTPS)
-  caddy:
-    image: caddy:2-alpine
-    container_name: beermachine_caddy
-    restart: unless-stopped
-    ports:
-      - "80:80"
-      - "443:443"
-      - "443:443/udp" # HTTP/3 support
-    volumes:
-      - ./Caddyfile:/etc/caddy/Caddyfile
-      - caddy_data:/data
-      - caddy_config:/config
-    environment:
-      # localhost default: safe on any remote (Caddy serves plain HTTP for
-      # localhost, no ACME attempts). Set your real domain in .env.
-      DOMAIN: ${DOMAIN:-localhost}
-    depends_on:
-      - frontend
-    networks:
-      - beermachine-network
-
   # PostgreSQL Database
   postgres:
     image: postgres:15-alpine
@@ -112,7 +86,7 @@ services:
         condition: service_healthy
     volumes:
       # Named volume instead of a host bind mount, so no repo checkout is required
-      # and the path is the same on every remote.
+      # and the path is the same on every host.
       - backend_uploads:/workspace/backend/uploads
     expose:
       - "${BEPORT:-8080}"
@@ -131,6 +105,10 @@ services:
       API_UPSTREAM: ${API_UPSTREAM:-http://backend:${BEPORT:-8080}}
     depends_on:
       - backend
+    ports:
+      # For host-level proxies that cannot reach Docker-internal networks.
+      # Container-based proxies (Coolify/Traefik) use frontend:80 directly.
+      - "${WEBPORT:-8080}:80"
     expose:
       - "80"
     networks:
@@ -138,8 +116,6 @@ services:
 
 volumes:
   postgres_data:
-  caddy_data:
-  caddy_config:
   backend_uploads:
 
 networks:

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -1,0 +1,133 @@
+# Copy-paste production deployment for beerswipe-v2 using prebuilt GHCR images.
+#
+# Unlike docker-compose.yml (which builds images from source), this file pulls
+# the images published by .github/workflows/docker-build-push.yml:
+#   - ghcr.io/athype/beerswipe-backend
+#   - ghcr.io/athype/beerswipe-frontend
+#
+# No source checkout, Node toolchain or build step is needed on the target host.
+#
+# Deploy on any remote with Docker + Compose v2 (>= 2.23):
+#   1. Put this file, the Caddyfile and a .env next to each other, e.g.:
+#        mkdir -p /opt/beerswipe && cd /opt/beerswipe
+#        # copy docker-compose.deploy.yml + Caddyfile + .env.example from this repo
+#   2. cp .env.example .env && nano .env
+#      -> MUST set JWT_SECRET, DB_PASSWORD, DOMAIN, RP_ID and FEURL for production.
+#      -> The defaults in this file let the stack boot, but are NOT secure.
+#   3. docker compose -f docker-compose.deploy.yml up -d
+#   4. docker compose -f docker-compose.deploy.yml logs -f caddy
+#
+# Update an existing deployment (pulls new images and recreates changed services):
+#   docker compose -f docker-compose.deploy.yml pull
+#   docker compose -f docker-compose.deploy.yml up -d
+#
+# Reproducible rollouts: pin images to a commit tag instead of latest, e.g.
+#   ghcr.io/athype/beerswipe-backend:sha-bb04677
+#
+# Requirements on the remote:
+#   - Docker Engine + Docker Compose v2
+#   - Ports 80 and 443 reachable (Caddy does automatic HTTPS via Let's Encrypt)
+#   - DNS A record for your domain pointing at the server (unless DOMAIN=localhost)
+#
+# Note: the production frontend build uses a relative /api/v1 path and nginx
+# proxies to the backend via API_UPSTREAM at container start, so no URL is
+# baked into the GHCR image. One image works on any remote.
+
+services:
+  # Caddy Reverse Proxy (automatic HTTPS)
+  caddy:
+    image: caddy:2-alpine
+    container_name: beermachine_caddy
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+      - "443:443/udp" # HTTP/3 support
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile
+      - caddy_data:/data
+      - caddy_config:/config
+    environment:
+      DOMAIN: ${DOMAIN:-beer.sv-ada.nl}
+    depends_on:
+      - frontend
+    networks:
+      - beermachine-network
+
+  # PostgreSQL Database
+  postgres:
+    image: postgres:15-alpine
+    container_name: beermachine_prod_db
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${DB_NAME:-beermachine}
+      POSTGRES_USER: ${DB_USER:-postgres}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-change-me}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    expose:
+      - "5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-postgres} -d ${DB_NAME:-beermachine}"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
+    networks:
+      - beermachine-network
+
+  # Backend API (prebuilt image from GHCR)
+  backend:
+    image: ghcr.io/athype/beerswipe-backend:latest
+    container_name: beermachine_backend
+    restart: unless-stopped
+    environment:
+      NODE_ENV: ${NODE_ENV:-production}
+      PORT: ${BEPORT:-8080}
+      JWT_SECRET: ${JWT_SECRET:-change-me}
+      DB_HOST: postgres
+      DB_PORT: 5432
+      DB_NAME: ${DB_NAME:-beermachine}
+      DB_USER: ${DB_USER:-postgres}
+      DB_PASSWORD: ${DB_PASSWORD:-change-me}
+      FEURL: ${FEURL:-https://beer.sv-ada.nl}
+      FEPORT: ${FEPORT:-443}
+      RP_NAME: ${RP_NAME:-Beer-Machine}
+      RP_ID: ${RP_ID:-beer.sv-ada.nl}
+      DOMAIN: ${DOMAIN:-beer.sv-ada.nl}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    volumes:
+      # Named volume instead of a host bind mount, so no repo checkout is required
+      # and the path is the same on every remote.
+      - backend_uploads:/workspace/backend/uploads
+    expose:
+      - "${BEPORT:-8080}"
+    networks:
+      - beermachine-network
+
+  # Frontend Web App (prebuilt image from GHCR, nginx + SPA)
+  frontend:
+    image: ghcr.io/athype/beerswipe-frontend:latest
+    container_name: beermachine_frontend
+    restart: unless-stopped
+    environment:
+      # Target of the /api/ proxy inside nginx (injected at container start).
+      API_UPSTREAM: ${API_UPSTREAM:-http://backend:8080}
+    depends_on:
+      - backend
+    expose:
+      - "80"
+    networks:
+      - beermachine-network
+
+volumes:
+  postgres_data:
+  caddy_data:
+  caddy_config:
+  backend_uploads:
+
+networks:
+  beermachine-network:
+    driver: bridge

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -1,9 +1,14 @@
-# Copy-paste production deployment for beerswipe-v2 using prebuilt GHCR images.
+# Copy-paste production deployment for beerswipe-v2 using prebuilt images.
 #
 # Unlike docker-compose.yml (which builds images from source), this file pulls
 # the images published by .github/workflows/docker-build-push.yml:
-#   - ghcr.io/athype/beerswipe-backend
-#   - ghcr.io/athype/beerswipe-frontend
+#   - ${DOCKER_REGISTRY:-ghcr.io}/${DOCKER_IMAGE_NAMESPACE:-athype}/beerswipe-backend
+#   - ${DOCKER_REGISTRY:-ghcr.io}/${DOCKER_IMAGE_NAMESPACE:-athype}/beerswipe-frontend
+#
+# The image location uses the same variables the build workflow honors
+# (DOCKER_REGISTRY, DOCKER_IMAGE_NAMESPACE), so forks and custom registries
+# work without editing YAML:
+#   DOCKER_REGISTRY=registry.example.com DOCKER_IMAGE_NAMESPACE=myorg
 #
 # No source checkout, Node toolchain or build step is needed on the target host.
 #
@@ -21,8 +26,8 @@
 #   docker compose -f docker-compose.deploy.yml pull
 #   docker compose -f docker-compose.deploy.yml up -d
 #
-# Reproducible rollouts: pin images to a commit tag instead of latest, e.g.
-#   ghcr.io/athype/beerswipe-backend:sha-bb04677
+# Reproducible rollouts: pin images to a commit tag instead of latest via the
+# IMAGE_TAG variable, e.g. IMAGE_TAG=sha-bb04677 in .env (no YAML edits).
 #
 # Requirements on the remote:
 #   - Docker Engine + Docker Compose v2
@@ -78,7 +83,7 @@ services:
 
   # Backend API (prebuilt image from GHCR)
   backend:
-    image: ghcr.io/athype/beerswipe-backend:latest
+    image: ${DOCKER_REGISTRY:-ghcr.io}/${DOCKER_IMAGE_NAMESPACE:-athype}/beerswipe-backend:${IMAGE_TAG:-latest}
     container_name: beermachine_backend
     restart: unless-stopped
     environment:
@@ -109,7 +114,7 @@ services:
 
   # Frontend Web App (prebuilt image from GHCR, nginx + SPA)
   frontend:
-    image: ghcr.io/athype/beerswipe-frontend:latest
+    image: ${DOCKER_REGISTRY:-ghcr.io}/${DOCKER_IMAGE_NAMESPACE:-athype}/beerswipe-frontend:${IMAGE_TAG:-latest}
     container_name: beermachine_frontend
     restart: unless-stopped
     environment:

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -53,7 +53,9 @@ services:
       - caddy_data:/data
       - caddy_config:/config
     environment:
-      DOMAIN: ${DOMAIN:-beer.sv-ada.nl}
+      # localhost default: safe on any remote (Caddy serves plain HTTP for
+      # localhost, no ACME attempts). Set your real domain in .env.
+      DOMAIN: ${DOMAIN:-localhost}
     depends_on:
       - frontend
     networks:
@@ -95,11 +97,13 @@ services:
       DB_NAME: ${DB_NAME:-beermachine}
       DB_USER: ${DB_USER:-postgres}
       DB_PASSWORD: ${DB_PASSWORD:-change-me}
-      FEURL: ${FEURL:-https://beer.sv-ada.nl}
+      # localhost-safe defaults; set FEURL/RP_ID/DOMAIN in .env for production
+      # (passkeys require RP_ID to match the site origin).
+      FEURL: ${FEURL:-http://localhost}
       FEPORT: ${FEPORT:-443}
       RP_NAME: ${RP_NAME:-Beer-Machine}
-      RP_ID: ${RP_ID:-beer.sv-ada.nl}
-      DOMAIN: ${DOMAIN:-beer.sv-ada.nl}
+      RP_ID: ${RP_ID:-${DOMAIN:-localhost}}
+      DOMAIN: ${DOMAIN:-localhost}
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -114,7 +114,9 @@ services:
     restart: unless-stopped
     environment:
       # Target of the /api/ proxy inside nginx (injected at container start).
-      API_UPSTREAM: ${API_UPSTREAM:-http://backend:8080}
+      # Defaults to backend:<BEPORT> so it stays in sync when only BEPORT is
+      # changed. Override only when proxying to an external/custom backend.
+      API_UPSTREAM: ${API_UPSTREAM:-http://backend:${BEPORT:-8080}}
     depends_on:
       - backend
     expose:


### PR DESCRIPTION
## Summary

Adds `docker-compose.deploy.yml`, a pull-only compose file for copy-paste deployment onto any remote, using the prebuilt images published to GHCR by the existing `docker-build-push.yml` workflow:

- `ghcr.io/athype/beerswipe-backend`
- `ghcr.io/athype/beerswipe-frontend`

No source checkout, Node toolchain or build step is needed on the target host.

## What changed

- **`docker-compose.deploy.yml`** (new): same service topology as the existing `docker-compose.yml` (caddy, postgres, backend, frontend) but with `image:` instead of `build:`. Every variable has a default so the stack boots with zero config; `.env` is only required to set real secrets (`JWT_SECRET`, `DB_PASSWORD`, `DOMAIN`, `RP_ID`, `FEURL`).
- **`docker-compose.deploy-host-proxy.yml`** (new): same stack without Caddy, for hosts that already have a reverse proxy (Coolify, Traefik, nginx). Binds no ports 80/443; the proxy targets `frontend:80` (container-based) or `127.0.0.1:${WEBPORT:-8080}` (host-level).
- **`README.md`**: new "Remote Deployment (Copy-Paste, Prebuilt Images)" section with copy/update commands, plus a variant subsection for hosts with their own reverse proxy.

## Design notes

- Works with the CI-built frontend image as-is: production builds use a relative `/api/v1` and nginx proxies via `API_UPSTREAM` at container start, so no URL is baked in.
- `API_UPSTREAM` defaults to `http://backend:${BEPORT}` (nested Compose interpolation), so the proxy target stays in sync when only `BEPORT` is changed; it can still be overridden explicitly for an external/custom backend target. `API_UPSTREAM` is commented out in `.env.example` so the derivation is not silently overridden.
- Backend uploads use a named volume (`backend_uploads`) instead of the `./backend/uploads` bind mount, so no repo checkout is required on the host.
- Postgres has a healthcheck and the backend waits for `service_healthy`, so first boot on a fresh remote does not crash-loop the API.
- The no-Caddy variant publishes the frontend on a configurable host port (`WEBPORT`, default 8080) for host-level proxies, while container-based proxies (Coolify/Traefik) reach `frontend:80` directly; `expose` is kept for both paths.
- Image references are parameterized: `${DOCKER_REGISTRY:-ghcr.io}/${DOCKER_IMAGE_NAMESPACE:-athype}/beerswipe-{backend,frontend}:${IMAGE_TAG:-latest}`. The variables mirror the build workflow's `DOCKER_REGISTRY` / `DOCKER_IMAGE_NAMESPACE`, so forks and custom registries work without YAML edits, and `IMAGE_TAG` pins rollouts to a commit tag.
- Domain-related defaults are localhost-safe: `DOMAIN`, `FEURL` and `RP_ID` default to `localhost`-based values (consistent with `docker-compose.yml`, which defaults `DOMAIN` to localhost), so a bare `up -d` on any remote serves plain HTTP via Caddy without triggering ACME for a domain you do not control. `RP_ID` derives from `DOMAIN` (matching the backend's own WebAuthn fallback `env.RP_ID || DOMAIN`), and real deployments set these in `.env`.

## Deployment

```bash
# on the remote, with the compose file + Caddyfile + .env in one folder
docker compose -f docker-compose.deploy.yml up -d
# update later
docker compose -f docker-compose.deploy.yml pull && docker compose -f docker-compose.deploy.yml up -d
```

## Verification

- GHCR images confirmed present and publicly pullable (`latest` tags).
- Compose file YAML-validated; service keys: caddy, postgres, backend, frontend.
- Not run end-to-end on a host (no Docker available in the environment where the branch was created).
