### PR TITLE
fix(compose): derive API_UPSTREAM default from BEPORT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,5 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+# Local git credentials (never commit)
+.git-credentials

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,7 @@ services:
         VITE_API_URL: ${BEURL}
         VITE_API_PORT: ${BEPORT}
     environment:
-      API_UPSTREAM: ${API_UPSTREAM:-http://backend:8080}
+      API_UPSTREAM: ${API_UPSTREAM:-http://backend:${BEPORT:-8080}}
     container_name: beermachine_frontend
     depends_on:
       - backend


### PR DESCRIPTION
## Summary

Same one-line fix as in #120, applied to the existing production `docker-compose.yml`: `API_UPSTREAM` now defaults to `http://backend:${BEPORT:-8080}` so the frontend nginx proxy stays in sync when only `BEPORT` is changed in `.env`. Previously, changing `BEPORT` silently broke the stack because the proxy kept targeting port 8080.

## Changes

- **`docker-compose.yml`**: `API_UPSTREAM: ${API_UPSTREAM:-http://backend:${BEPORT:-8080}}` (nested Compose interpolation, documented form in the Compose spec: `${VARIABLE:-${FOO:-default}}`).
- **`.gitignore`**: ignore `.git-credentials` (local git credential store used on dev machines; must never be committed).

## Notes

- Nested interpolation semantics verified against the Compose spec and simulated: defaults only -> `http://backend:8080`; `BEPORT=9000` -> `http://backend:9000`; explicit `API_UPSTREAM` still wins when set.
- `.env.example` documentation for the derivation was already updated in #120.
- Backend `PORT` and `expose` already read `BEPORT`; this change makes the frontend proxy consistent with them.
